### PR TITLE
chore: migrate to OIDC publishing for npm releases

### DIFF
--- a/.changeset/oidc-publish.md
+++ b/.changeset/oidc-publish.md
@@ -1,0 +1,5 @@
+---
+"@elecdeer/stylelint-rscss": patch
+---
+
+chore: migrate to OIDC publishing for npm releases

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Enable corepack
         run: corepack enable pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 20.x
           cache: "pnpm"

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Enable corepack
         run: corepack enable pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.2.0
         with:
           node-version: 20.x
           cache: "pnpm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Enable corepack
         run: corepack enable pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.2.0
         with:
           node-version: 20.x
           cache: "pnpm"
@@ -38,7 +38,7 @@ jobs:
         run: pnpm run build
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@v1.6.0
         with:
           publish: "pnpm exec changeset publish"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
 
       # oidc publish requires npm@11.5.1+
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.8.0
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Enable corepack
         run: corepack enable pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 20.x
           cache: "pnpm"
@@ -38,7 +38,7 @@ jobs:
         run: pnpm run build
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1.6.0
+        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
         with:
           publish: "pnpm exec changeset publish"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,12 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
+
+      # oidc publish requires npm@11.5.1+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -43,4 +48,3 @@ jobs:
           publish: "pnpm exec changeset publish"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
 	"name": "@elecdeer/stylelint-rscss",
 	"description": "Validate CSS (and SCSS, Less, SugarSS) to RSCSS conventions",
 	"version": "1.0.4",
-	"author": "Rico Sta. Cruz <rico@ricostacruz.com> (http://ricostacruz.com)",
+	"author": "elecdeer (https://github.com/elecdeer)",
+	"contributors": [
+		"Rico Sta. Cruz <rico@ricostacruz.com> (http://ricostacruz.com)"
+	],
 	"license": "MIT",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

This PR migrates the npm package publishing workflow from using `NPM_TOKEN` secrets to OpenID Connect (OIDC) authentication, improving security by eliminating the need to store long-lived tokens.

## Changes

### Workflow Updates
- **Updated GitHub Actions versions**: Pin `actions/checkout` to v6.0.1 and `actions/setup-node` to v6.2.0 with commit SHA for security
- **Pin changesets/action**: Updated to v1.6.0 with commit SHA
- **Configure npm registry**: Added `registry-url` configuration to setup-node action
- **Update npm version**: Added step to install npm@latest (requires npm@11.5.1+ for OIDC support)
- **Remove NPM_TOKEN**: Removed the `NPM_TOKEN` secret from workflow environment variables
- **Add OIDC permissions**: Added `id-token: write` permission to enable OIDC token generation

### Package Metadata
- Updated package author information to reflect current maintainer
- Added original author to contributors list

## Related Issues

None found.

## Notes

This change requires configuring OIDC publishing on npm. The repository needs to have trusted publishing configured to allow GitHub Actions to publish packages without explicit tokens.